### PR TITLE
Fix string ptr increase after recursion

### DIFF
--- a/json.c
+++ b/json.c
@@ -86,6 +86,9 @@ static JSONObject * _parseJSON(string str, int * offset) {
             removeWhitespaceCalcOffset(str, _offset);
             
             if(*str == '{') {
+                int _offsetBeforeParsingChildObject = _offset;
+                int _sizeOfChildObject;
+
                 tempPtr.value = new(JSONValue);
                 tempPtr.type = JSON_OBJECT;
                 tempPtr.value->jsonObject = _parseJSON(str, &_offset);
@@ -93,7 +96,9 @@ static JSONObject * _parseJSON(string str, int * offset) {
                     freeJSONFromMemory(obj);
                     return NULL;
                 }
-                str += _offset;
+                // Advance the string pointer by the size of the processed child object
+                _sizeOfChildObject = _offset - _offsetBeforeParsingChildObject;
+                str += _sizeOfChildObject;
             } else if(*str == '"') {
                 i = strNextOccurence(++str, '"');
                 if(i == -1) {


### PR DESCRIPTION
### Problem:
The code can enter an infinite loop after parsing a complex string that requires recursion.

### Cause:
After recursively parsing of a child object, the string pointer is not incremented correctly. It is increased by the current _offset, rather than only the size of the child/recursed object(s).

e.g.
```
{"name":{"first":"John", "last":"Doe"}, "age":"21"}
0----+----1----+----2----+----3----+----4----+----
        0----+----1----+----2----+----
```
After parsing {"first":"John", "last":"Doe"}, the string pointer is incorrectly advanced to the "2", instead of the ",".

### Solution:
Increment the string pointer by the size of the recursed child objects, rather than the current (already incremented) _offset.
