### PR TITLE
added parsing of numerical values

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,21 @@ Value: world
 ```C
 #include "json.h"
 
-char * complexJson = "{\"name":{\"first\":\"John\",\"last\":\"Doe\"},\"age\":\"21\"}";
+char * complexJson = "{\"name\":{\"first\":\"John\",\"last\":\"Doe\"},\"age\":21.5}";
 
 int main(int argc, const char * argv[]) {
-  JSONObject *json = parseJSON(complexJsonString);
+  JSONObject *json = parseJSON(complexJson);
   JSONObject *nameJson = json->pairs[0].value->jsonObject;
-  printf("First name: %s\nLast name: %s\n", nameJson->pairs[0]->value.stringValue, nameJson->pairs[1]->value.stringValue);
+  printf("First name: %s\nLast name: %s Age: %f\n", nameJson->pairs[0].value->stringValue,
+                                                    nameJson->pairs[1].value->stringValue,
+                                                    json->pairs[1].value->doubleValue);
   return 0;
 }
 ```
 
 ### FAQs
 
-#### How to know whether the current value is a String or JSON?
+#### How to know whether the current value is a String, Double or JSON?
 
 At each Key-Value `JSONPair` pair, there is a member named `type`
 
@@ -67,6 +69,8 @@ At each Key-Value `JSONPair` pair, there is a member named `type`
 JSONObject *json = parseJSON(someJsonString);
 if(json->pairs[0].type == JSON_STRING) {
   // String value
+} else if(json->pairs[0].type == JSON_DOUBLE) {
+  // Double precision floating point value
 } else {
   // JSON object
 }

--- a/json.h
+++ b/json.h
@@ -17,6 +17,8 @@ typedef unsigned char                           bool;
 #define newWithSize(x, y)                       (x *) malloc(y * sizeof(x))
 #define renewWithSize(x, y, z)                  (y *) realloc(x, z * sizeof(y))
 #define isWhitespace(x)                         x == '\r' || x == '\n' || x == '\t' || x == ' '
+#define isNumeral(x)                            (x >= '0' && x <= '9') || x == 'e' || x == 'E' \
+                                                || x == '.'  || x == '+' || x == '-'
 #define removeWhitespace(x)                     while(isWhitespace(*x)) x++
 #define removeWhitespaceCalcOffset(x, y)        while(isWhitespace(*x)) { x++; y++; }
 
@@ -28,6 +30,7 @@ union _jsonvalue;
 
 typedef enum {
     JSON_STRING = 0,
+    JSON_DOUBLE,
     JSON_OBJECT
 } JSONValueType;
 
@@ -44,12 +47,14 @@ typedef struct _jsonpair {
 
 typedef union _jsonvalue {
     string stringValue;
+    double doubleValue;
     struct _jsonobject *jsonObject;
 } JSONValue;
 
 JSONObject *parseJSON(string);
 void freeJSONFromMemory(JSONObject *);
 static int strNextOccurence(string, char);
+static int strNextNonNumeral(string);
 static JSONObject * _parseJSON(string, int *);
 
 


### PR DESCRIPTION
This pull request makes numerical values without quotes such as `"age":23.5` go into `.....->doubleValue` of type `double` which could be type-casted to caller needs for further use e.g. if `int` were required. Type indicator is `JSON_DOUBLE`.

Fixes #3 