### PR TITLE
Fix memory leak in obj->entries hash map

### DIFF
--- a/json.c
+++ b/json.c
@@ -916,6 +916,7 @@ void json_free_object(typed(json_object) * object) {
     if (entry != NULL) {
       free((void *)entry->key);
       json_free(&entry->element);
+      free(entry);
     }
   }
 


### PR DESCRIPTION
Allocated by `json_parse_object` when generating the hash map.