### PR TITLE
Stop json_object_find from dereferencing empty hash buckets

### DIFF
--- a/json.c
+++ b/json.c
@@ -681,6 +681,8 @@ result(json_element)
   // obj->count misses in the worst case
   for (size_t i = 0; i < obj->count; i++) {
     typed(json_entry) *entry = obj->entries[bucket];
+    if (entry == NULL)
+      break;
     if (strcmp(key, entry->key) == 0)
       return result_ok(json_element)(entry->element);
 


### PR DESCRIPTION
`json_object_find` probes the open-addressing table for `obj->count` steps but never checks whether a slot is empty, so `strcmp(key, entry->key)` runs even when `entry` is NULL. When a parsed object has fewer stored entries than `count` (which `json_parse_object` can produce on some malformed input, where the counting pass and the insertion pass disagree), looking up an absent key walks into a NULL bucket and segfaults. Fixes #29.

A NULL slot means the probe sequence is exhausted, so I break out and return `JSON_ERROR_INVALID_KEY`, which is the same result a normal miss already returns. Reproduced under ASAN before the change (SEGV at json.c:684) and confirmed it now returns an error; existing successful and missing-key lookups on well-formed objects are unaffected.
